### PR TITLE
ci: fixes the non-triggering release job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - '**'
   pull_request:
 
 
@@ -26,8 +28,10 @@ jobs:
           AUTH0_CLIENT_SECRET: "${{ secrets.AUTH0_CLIENT_SECRET }}"
   publish:
     if: startsWith(github.ref, 'refs/tags/')
-    needs: build_test
+    needs: [ build_test ]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout Code
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0


### PR DESCRIPTION
## Description
On tags event was missing on the CI pipeline manifest meaning that the publish job is never triggered. Also missing `write` permissions on contents on GH Token.